### PR TITLE
DM-8662 change PYTHONPATH to ${PRODUCT_DIR}/lib/python

### DIFF
--- a/ups/firefly_client.table
+++ b/ups/firefly_client.table
@@ -1,4 +1,4 @@
 setupRequired(ws4py)
 setupRequired(python_future)
 
-envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
+envPrepend(PYTHONPATH, ${PRODUCT_DIR}/lib/python)


### PR DESCRIPTION
In my development of DM-8296, I had tested the import of firefly_client from the base directory of the repository. This bug fix makes the import work from other directories.