### PR TITLE
DM-22234: Remove python 2 support

### DIFF
--- a/firefly_client/firefly_client.py
+++ b/firefly_client/firefly_client.py
@@ -4,9 +4,6 @@ Module of firefly_client.py
 This module defines class 'FireflyClient' and methods to remotely communicate to Firefly viewer
 by dispatching remote actions.
 """
-from __future__ import print_function
-from future import standard_library
-from builtins import str
 from ws4py.client.threadedclient import WebSocketClient
 from ws4py.client import HandshakeError
 import os
@@ -1587,7 +1584,7 @@ class FireflyClient(WebSocketClient):
             serialized_rv = self._create_rangevalues_zscale(algorithm, **additional_params)
         elif stype and (stype.lower() in ['minmax', 'maxmin']):
             # 'maxmin' retained for backwards compatibility
-            serialized_rv = self._create_rangevalues_standard(algorithm, 'percent', 
+            serialized_rv = self._create_rangevalues_standard(algorithm, 'percent',
                                                               lower_value=0, upper_value=100, **additional_params)
         else:
             serialized_rv = self._create_rangevalues_standard(algorithm, stype, **additional_params)

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,6 +1,4 @@
 
-from __future__ import absolute_import, division, print_function
-
 import socket
 import unittest
 

--- a/ups/firefly_client.table
+++ b/ups/firefly_client.table
@@ -1,4 +1,3 @@
 setupRequired(ws4py)
-setupRequired(python_future)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/lib/python)


### PR DESCRIPTION
@stargaser not entirely sure what you want to do with these commits but I was scanning through the lsst_distrib dependencies and found we still had some residual python_future stuff hanging around in here.

I resisted the urge to make the code base PEP8 compliant since I wasn't sure what your plan was for that.