### PR TITLE
Fix for setuptools >= 49

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -2,4 +2,5 @@ install() {
   PYDEST="$PREFIX/lib/python"
   PYTHONPATH="$PYDEST:$PYTHONPATH" \
      eval python setup.py install --single-version-externally-managed --record record.txt  $PYSETUP_INSTALL_OPTIONS
+  install_ups
 }

--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,0 +1,5 @@
+install() {
+  PYDEST="$PREFIX/lib/python"
+  PYTHONPATH="$PYDEST:$PYTHONPATH" \
+     eval python setup.py install --single-version-externally-managed --record record.txt  $PYSETUP_INSTALL_OPTIONS
+}


### PR DESCRIPTION
setup.py install is broken in eups 2.1.5 with setuptools 49. This PR uses the setup.py install procedure that's in eups master, but not in any current release of eups. That form works fine.

This is needed for the new environment as a result for RFC-715